### PR TITLE
fix(windows): remove element.render

### DIFF
--- a/lua/dapui/windows/init.lua
+++ b/lua/dapui/windows/init.lua
@@ -169,7 +169,6 @@ function M.open_float(name, element, position, settings)
       resize()
     end,
   })
-  element.render()
   -- In case render doesn't trigger on_lines
   resize()
 


### PR DESCRIPTION
Buffers can be assumed to have already rendered when opening in a window.

See #265